### PR TITLE
Fixing XSS vulnerability

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -25,7 +25,7 @@ module WordToMarkdownServer
         render_template :index, { :error => error }
       end
       md = WordToMarkdown.new(params['doc'][:tempfile]).to_s
-      html = HTML::Pipeline::MarkdownFilter.new(md).call
+      html = HTML::Pipeline::MarkdownFilter.new(CGI.escapeHTML(md)).call
       render_template :display, { :md => md, :html => html, :filename => params['doc'][:filename].sub(/\.docx?$/,"") }
     end
 

--- a/server.rb
+++ b/server.rb
@@ -24,8 +24,8 @@ module WordToMarkdownServer
         error = "It looks like you tried to upload something other than a Word Document."
         render_template :index, { :error => error }
       end
-      md = WordToMarkdown.new(params['doc'][:tempfile]).to_s
-      html = HTML::Pipeline::MarkdownFilter.new(CGI.escapeHTML(md)).call
+      md = CGI.escapeHTML(WordToMarkdown.new(params['doc'][:tempfile]).to_s)
+      html = HTML::Pipeline::MarkdownFilter.new(md).call
       render_template :display, { :md => md, :html => html, :filename => params['doc'][:filename].sub(/\.docx?$/,"") }
     end
 


### PR DESCRIPTION
HTML-encoded the Markdown before rendering as HTML to remediate the [Reflected XSS vulnerability](https://github.com/benbalter/word-to-markdown/issues/72)